### PR TITLE
[ERP-1935] Update environs and other dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+
+updates:
+    -   package-ecosystem: "pip"
+        directory: "/"
+        schedule:
+            interval: "weekly"
+
+    -   package-ecosystem: "github-actions"
+        directory: "/"
+        schedule:
+            interval: "weekly"

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -43,8 +43,8 @@ jobs:
         run: python -m pip install --upgrade --no-cache-dir setuptools
       - name: Install dev dependencies
         run: python -m pip install -r requirements-dev.txt
-      - name: Analysing the dependencies with safety
-        run: make safety
+      - name: Analysing the dependencies vulnerabilities
+        run: make dep-vulnerabilities
 
   unittests:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-notes.yaml
+++ b/.github/workflows/release-notes.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Generate release notes
         uses: ./
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .idea
 venv
+.venv
 __pycache__/
 *.py[cod]
 .coverage

--- a/.safety-policy.yml
+++ b/.safety-policy.yml
@@ -1,9 +1,0 @@
-# Safety Security and License Configuration file
-security:
-  ignore-cvss-severity-below: 0
-  ignore-cvss-unknown-severity: False
-  ignore-vulnerabilities:
-    70612:
-      # CVE-2019-8341: https://data.safetycli.com/v/70612/97c
-      # ADVISORY: In Jinja2, the from_string function is prone to Server Side Template Injection (SSTI) where it takes the "source" parameter as...
-  continue-on-vulnerability-error: False

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,7 @@ ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1
 
 RUN apt-get update \
-    && pip install --upgrade --no-cache-dir pip \
-    && pip install --upgrade --no-cache-dir wheel \
-    && pip install --upgrade --no-cache-dir setuptools
+    && pip install --upgrade --no-cache-dir pip wheel setuptools
 
 COPY . .
 

--- a/Makefile
+++ b/Makefile
@@ -9,9 +9,8 @@ lint:
 	pylint $(shell git ls-files '*.py')
 	PYTHONPATH=/ mypy --namespace-packages --show-error-codes . --check-untyped-defs --ignore-missing-imports --show-traceback
 
-safety:
-	safety check --policy-file .safety-policy.yml
-
+dep-vulnerabilities:
+	pip-audit
 
 test:
 	coverage run -m unittest tests/test_*

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,13 +1,12 @@
 -r requirements.txt
 
-black==24.4.0
-isort==5.13.2
-flake8==7.0.0
+black==25.1.0
+isort==6.0.1
+flake8==7.2.0
 flake8-bandit==4.1.1
-flake8-quotes==3.3.2
-pylint==3.0.3
-mypy==1.8.0
-safety==3.2.4
-types-requests==2.32.0.20240712
-pytest>=8.3.3
-coverage>=7.6.1
+flake8-quotes==3.4.0
+pylint==3.3.6
+mypy==1.15.0
+types-requests==2.32.0.20250328
+coverage==7.8.0
+pip-audit==2.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
-environs==10.3.0
-PyGithub==2.3.0
+requests==2.32.3
+environs==14.1.1
+PyGithub==2.6.1


### PR DESCRIPTION
[[ERP-1935] [Release Notes Action] Обновить пакет environs](https://tracker.yandex.ru/ERP-1935)

- environs<=10 uses marshmallow but there was recent major update which removed some deprecated logic
As a result, environs was broken
- Replace safety with pip-audit for checking security vulnerabilities